### PR TITLE
Add history data from Uruguay

### DIFF
--- a/data/uruguay/README.md
+++ b/data/uruguay/README.md
@@ -1,6 +1,6 @@
 ## Uruguay
 
-> Last updated at May 12 2020 00:38:44 UTC.
+> Last updated at May 12 2020 18:26:20 UTC.
 
 
 | Departament | Dataset |

--- a/data/uruguay/uy-ca.csv
+++ b/data/uruguay/uy-ca.csv
@@ -3,6 +3,7 @@ date,iso,region,city,place_type,cases,deaths,recovered
 2020-04-27,UY-CA,Canelones,,departamento,84,2,63
 2020-04-28,UY-CA,Canelones,,departamento,85,2,64
 2020-04-29,UY-CA,Canelones,,departamento,85,2,66
+2020-04-30,UY-CA,Canelones,,departamento,85,2,66
 2020-05-03,UY-CA,Canelones,,departamento,89,2,72
 2020-05-04,UY-CA,Canelones,,departamento,89,2,72
 2020-05-05,UY-CA,Canelones,,departamento,91,2,72

--- a/data/uruguay/uy-co.csv
+++ b/data/uruguay/uy-co.csv
@@ -3,6 +3,7 @@ date,iso,region,city,place_type,cases,deaths,recovered
 2020-04-27,UY-CO,Colonia,,departamento,8,,6
 2020-04-28,UY-CO,Colonia,,departamento,8,,6
 2020-04-29,UY-CO,Colonia,,departamento,8,,6
+2020-04-30,UY-CO,Colonia,,departamento,8,,6
 2020-05-03,UY-CO,Colonia,,departamento,8,,6
 2020-05-04,UY-CO,Colonia,,departamento,8,,6
 2020-05-05,UY-CO,Colonia,,departamento,8,,6

--- a/data/uruguay/uy-du.csv
+++ b/data/uruguay/uy-du.csv
@@ -3,6 +3,7 @@ date,iso,region,city,place_type,cases,deaths,recovered
 2020-04-27,UY-DU,Durazno,,departamento,1,,0
 2020-04-28,UY-DU,Durazno,,departamento,1,,0
 2020-04-29,UY-DU,Durazno,,departamento,1,,0
+2020-04-30,UY-DU,Durazno,,departamento,1,,1
 2020-05-03,UY-DU,Durazno,,departamento,1,,1
 2020-05-04,UY-DU,Durazno,,departamento,1,,1
 2020-05-05,UY-DU,Durazno,,departamento,1,,1

--- a/data/uruguay/uy-fs.csv
+++ b/data/uruguay/uy-fs.csv
@@ -3,6 +3,7 @@ date,iso,region,city,place_type,cases,deaths,recovered
 2020-04-27,UY-FS,Flores,,departamento,1,,1
 2020-04-28,UY-FS,Flores,,departamento,1,,1
 2020-04-29,UY-FS,Flores,,departamento,1,,1
+2020-04-30,UY-FS,Flores,,departamento,1,,1
 2020-05-03,UY-FS,Flores,,departamento,1,,1
 2020-05-04,UY-FS,Flores,,departamento,1,,1
 2020-05-05,UY-FS,Flores,,departamento,1,,1

--- a/data/uruguay/uy-la.csv
+++ b/data/uruguay/uy-la.csv
@@ -3,6 +3,7 @@ date,iso,region,city,place_type,cases,deaths,recovered
 2020-04-27,UY-LA,Lavalleja,,departamento,4,,2
 2020-04-28,UY-LA,Lavalleja,,departamento,4,,3
 2020-04-29,UY-LA,Lavalleja,,departamento,4,,4
+2020-04-30,UY-LA,Lavalleja,,departamento,4,,4
 2020-05-03,UY-LA,Lavalleja,,departamento,4,,4
 2020-05-04,UY-LA,Lavalleja,,departamento,4,,4
 2020-05-05,UY-LA,Lavalleja,,departamento,4,,4

--- a/data/uruguay/uy-ma.csv
+++ b/data/uruguay/uy-ma.csv
@@ -3,6 +3,7 @@ date,iso,region,city,place_type,cases,deaths,recovered
 2020-04-27,UY-MA,Maldonado,,departamento,24,3,13
 2020-04-28,UY-MA,Maldonado,,departamento,24,3,13
 2020-04-29,UY-MA,Maldonado,,departamento,24,3,13
+2020-04-30,UY-MA,Maldonado,,departamento,25,3,14
 2020-05-03,UY-MA,Maldonado,,departamento,25,4,14
 2020-05-04,UY-MA,Maldonado,,departamento,25,4,14
 2020-05-05,UY-MA,Maldonado,,departamento,25,4,14

--- a/data/uruguay/uy-mo.csv
+++ b/data/uruguay/uy-mo.csv
@@ -3,6 +3,7 @@ date,iso,region,city,place_type,cases,deaths,recovered
 2020-04-27,UY-MO,Montevideo,,departamento,457,10,272
 2020-04-28,UY-MO,Montevideo,,departamento,466,10,278
 2020-04-29,UY-MO,Montevideo,,departamento,471,10,282
+2020-04-30,UY-MO,Montevideo,,departamento,475,10,298
 2020-05-03,UY-MO,Montevideo,,departamento,495,11,319
 2020-05-04,UY-MO,Montevideo,,departamento,495,11,319
 2020-05-05,UY-MO,Montevideo,,departamento,494,11,323

--- a/data/uruguay/uy-pa.csv
+++ b/data/uruguay/uy-pa.csv
@@ -3,6 +3,7 @@ date,iso,region,city,place_type,cases,deaths,recovered
 2020-04-27,UY-PA,Paysandú,,departamento,1,,1
 2020-04-28,UY-PA,Paysandú,,departamento,1,,1
 2020-04-29,UY-PA,Paysandú,,departamento,1,,1
+2020-04-30,UY-PA,Paysandú,,departamento,1,,1
 2020-05-03,UY-PA,Paysandú,,departamento,1,,1
 2020-05-04,UY-PA,Paysandú,,departamento,1,,1
 2020-05-05,UY-PA,Paysandú,,departamento,1,,1

--- a/data/uruguay/uy-rn.csv
+++ b/data/uruguay/uy-rn.csv
@@ -3,6 +3,7 @@ date,iso,region,city,place_type,cases,deaths,recovered
 2020-04-27,UY-RN,Río Negro,,departamento,9,,5
 2020-04-28,UY-RN,Río Negro,,departamento,9,,7
 2020-04-29,UY-RN,Río Negro,,departamento,9,,8
+2020-04-30,UY-RN,Río Negro,,departamento,9,,8
 2020-05-03,UY-RN,Río Negro,,departamento,9,,8
 2020-05-04,UY-RN,Río Negro,,departamento,9,,8
 2020-05-05,UY-RN,Río Negro,,departamento,9,,8

--- a/data/uruguay/uy-ro.csv
+++ b/data/uruguay/uy-ro.csv
@@ -3,6 +3,7 @@ date,iso,region,city,place_type,cases,deaths,recovered
 2020-04-27,UY-RO,Rocha,,departamento,1,,1
 2020-04-28,UY-RO,Rocha,,departamento,1,,1
 2020-04-29,UY-RO,Rocha,,departamento,1,,1
+2020-04-30,UY-RO,Rocha,,departamento,1,,1
 2020-05-03,UY-RO,Rocha,,departamento,1,,1
 2020-05-04,UY-RO,Rocha,,departamento,1,,1
 2020-05-05,UY-RO,Rocha,,departamento,1,,1

--- a/data/uruguay/uy-sa.csv
+++ b/data/uruguay/uy-sa.csv
@@ -3,6 +3,7 @@ date,iso,region,city,place_type,cases,deaths,recovered
 2020-04-27,UY-SA,Salto,,departamento,12,,10
 2020-04-28,UY-SA,Salto,,departamento,12,,10
 2020-04-29,UY-SA,Salto,,departamento,12,,10
+2020-04-30,UY-SA,Salto,,departamento,12,,10
 2020-05-03,UY-SA,Salto,,departamento,12,,12
 2020-05-04,UY-SA,Salto,,departamento,12,,12
 2020-05-05,UY-SA,Salto,,departamento,12,,12

--- a/data/uruguay/uy-sj.csv
+++ b/data/uruguay/uy-sj.csv
@@ -3,6 +3,7 @@ date,iso,region,city,place_type,cases,deaths,recovered
 2020-04-27,UY-SJ,San José,,departamento,3,,0
 2020-04-28,UY-SJ,San José,,departamento,3,,1
 2020-04-29,UY-SJ,San José,,departamento,3,,1
+2020-04-30,UY-SJ,San José,,departamento,3,,1
 2020-05-03,UY-SJ,San José,,departamento,3,,2
 2020-05-04,UY-SJ,San José,,departamento,3,,2
 2020-05-05,UY-SJ,San José,,departamento,4,,3

--- a/data/uruguay/uy-so.csv
+++ b/data/uruguay/uy-so.csv
@@ -3,6 +3,7 @@ date,iso,region,city,place_type,cases,deaths,recovered
 2020-04-27,UY-SO,Soriano,,departamento,1,,1
 2020-04-28,UY-SO,Soriano,,departamento,1,,1
 2020-04-29,UY-SO,Soriano,,departamento,1,,1
+2020-04-30,UY-SO,Soriano,,departamento,1,,1
 2020-05-03,UY-SO,Soriano,,departamento,1,,1
 2020-05-04,UY-SO,Soriano,,departamento,1,,1
 2020-05-05,UY-SO,Soriano,,departamento,1,,1

--- a/data/uruguay/uy-tt.csv
+++ b/data/uruguay/uy-tt.csv
@@ -1,6 +1,7 @@
 date,iso,region,city,place_type,cases,deaths,recovered
 2020-04-28,UY-TT,Treinta y Tres,,departamento,4,,0
 2020-04-29,UY-TT,Treinta y Tres,,departamento,4,,0
+2020-04-30,UY-TT,Treinta y Tres,,departamento,4,,0
 2020-05-03,UY-TT,Treinta y Tres,,departamento,5,,0
 2020-05-04,UY-TT,Treinta y Tres,,departamento,5,,0
 2020-05-05,UY-TT,Treinta y Tres,,departamento,5,,0


### PR DESCRIPTION
Source [https://web.archive.org/web/*/https://es.wikipedia.org/wiki/Pandemia_de_enfermedad_por_coronavirus_de_2020_en_Uruguay](https://web.archive.org/web/*/https://es.wikipedia.org/wiki/Pandemia_de_enfermedad_por_coronavirus_de_2020_en_Uruguay) from dates:

- 2020-04-30