### PR TITLE
Update countries source

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,23 +4,25 @@ Scraping world-wide data about COVID-19.
 
 ## Sources
 
-* `/data/countries/`: [European Centre for Disease Prevention and Control](https://www.ecdc.europa.eu/en/publications-data/download-todays-data-geographic-distribution-covid-19-cases-worldwide)
-* `/data/brazil/`: [Brasil.IO](https://brasil.io/dataset/covid19/caso)
-* `/data/sweden/`: [Public Health Agency of Sweden](https://www.folkhalsomyndigheten.se/smittskydd-beredskap/utbrott/aktuella-utbrott/covid-19/aktuellt-epidemiologiskt-lage), [City Population](http://citypopulation.de/en/sweden/cities/mun/)
-* `/data/united_states_of_america/`: [NY Times](https://github.com/nytimes/covid-19-data)
-* `/data/spain/`: [Instituto de Salud Calors III](https://covid19.isciii.es/)
-* `/data/united_kingdom/`: [Public Health England](https://www.gov.uk/government/publications/covid-19-track-coronavirus-cases), [emmadoughty/Daily_COVID-19](https://github.com/emmadoughty/Daily_COVID-19)
-* `/data/chile/`: [Ministerio de Salud](https://www.minsal.cl/nuevo-coronavirus-2019-ncov/casos-confirmados-en-chile-covid-19/)
-* `/data/bolivia/`: [Ministerio de Salud](https://boliviasegura.gob.bo/)
-* `/data/argentina/`: [Diario La Nación](https://www.lanacion.com.ar)
+- `/data/countries/`:
+  - [Our World in Data: Coronavirus Pandemic (COVID-19) – the data](https://ourworldindata.org/coronavirus-data)
+  - [European Centre for Disease Prevention and Control](https://www.ecdc.europa.eu/en/publications-data/download-todays-data-geographic-distribution-covid-19-cases-worldwide) **[DEPRECATED]**
+- `/data/brazil/`: [Brasil.IO](https://brasil.io/dataset/covid19/caso)
+- `/data/sweden/`: [Public Health Agency of Sweden](https://www.folkhalsomyndigheten.se/smittskydd-beredskap/utbrott/aktuella-utbrott/covid-19/aktuellt-epidemiologiskt-lage), [City Population](http://citypopulation.de/en/sweden/cities/mun/)
+- `/data/united_states_of_america/`: [NY Times](https://github.com/nytimes/covid-19-data)
+- `/data/spain/`: [Instituto de Salud Calors III](https://covid19.isciii.es/)
+- `/data/united_kingdom/`: [Public Health England](https://www.gov.uk/government/publications/covid-19-track-coronavirus-cases), [emmadoughty/Daily_COVID-19](https://github.com/emmadoughty/Daily_COVID-19)
+- `/data/chile/`: [Ministerio de Salud](https://www.minsal.cl/nuevo-coronavirus-2019-ncov/casos-confirmados-en-chile-covid-19/)
+- `/data/bolivia/`: [Ministerio de Salud](https://boliviasegura.gob.bo/)
+- `/data/argentina/`: [Diario La Nación](https://www.lanacion.com.ar)
 
 ## Built with
 
-* Python
-* [pipenv](https://github.com/pypa/pipenv)
-* [requests](https://requests.readthedocs.io/en/master/)
-* [BeautifulSoup](https://www.crummy.com/software/BeautifulSoup/bs4/doc/)
-* [pandas](https://pandas.pydata.org/)
+- Python
+- [pipenv](https://github.com/pypa/pipenv)
+- [requests](https://requests.readthedocs.io/en/master/)
+- [BeautifulSoup](https://www.crummy.com/software/BeautifulSoup/bs4/doc/)
+- [pandas](https://pandas.pydata.org/)
 
 ## License
 

--- a/countries.py
+++ b/countries.py
@@ -5,7 +5,8 @@ import pandas as pd
 
 from helpers import ensure_dirs
 
-COUNTRIES_DATA = 'https://opendata.ecdc.europa.eu/covid19/casedistribution/csv'
+# COUNTRIES_DATA = 'https://opendata.ecdc.europa.eu/covid19/casedistribution/csv'
+COUNTRIES_DATA = 'https://covid.ourworldindata.org/data/owid-covid-data.csv'
 
 
 def scrape_countries():
@@ -16,13 +17,24 @@ def scrape_countries():
     countries = {}
     df = pd.read_csv(COUNTRIES_DATA, parse_dates=[0], dayfirst=True)
 
-    for country in df['countriesAndTerritories'].unique():
-        is_country = df['countriesAndTerritories'] == country
+    for country in df['location'].unique():
+        is_country = df['location'] == country
         country_filename = country.lower().replace(' ', '_') + '.csv'
         country_file = path.join(countries_dir, country_filename)
         countries[country] = country_filename
 
         country_df = df[is_country]
+
+        country_df.rename(columns={
+            "date": "dateRep",
+            "new_cases": "cases",
+            "new_deaths": "deaths",
+            "location": "countriesAndTerritories",
+            "iso_code": "countryterritoryCode",
+            "population": "popData2019",
+            "continent": "continentExp",
+        }, inplace=True)
+
         country_df.to_csv(country_file, index=False, float_format='%.f')
 
     with open(path.join(countries_dir, 'README.md'), 'w') as readme_f:

--- a/generate_metadata.py
+++ b/generate_metadata.py
@@ -21,7 +21,7 @@ def meta_countries(countries={}):
         countries[country_key] = {
             'name': head.countriesAndTerritories,
             'file': country_file,
-            'geoId': head.geoId,
+            # 'geoId': head.geoId,
             'countryTerritoryCode': head.countryterritoryCode,
             'regions': {},
             'parent': head.continentExp,
@@ -125,7 +125,7 @@ def meta_sweden(countries={}):
 
 def meta_united_kingdom(countries={}):
     regions_file = glob.glob('data/united_kingdom/*.csv')
-    country = 'United_Kingdom'
+    country = 'United Kingdom'
 
     regions = {}
 
@@ -158,9 +158,9 @@ def meta_united_kingdom(countries={}):
     return countries
 
 
-def meta_united_states_of_america(countries={}):
-    regions_file = glob.glob('data/united_states_of_america/*.csv')
-    country = 'United_States_of_America'
+def meta_united_states(countries={}):
+    regions_file = glob.glob('data/united_states/*.csv')
+    country = 'United States'
 
     regions = {}
 
@@ -435,7 +435,7 @@ if __name__ == "__main__":
         meta_spain,
         meta_sweden,
         meta_united_kingdom,
-        meta_united_states_of_america,
+        meta_united_states,
         meta_chile,
         meta_bolivia,
         meta_argentina,


### PR DESCRIPTION
Since [ECDC](https://www.ecdc.europa.eu/en/publications-data/download-todays-data-geographic-distribution-covid-19-cases-worldwide) updated data structure to a weekly period, this PR changes countries data source to use [Our World in Data: Coronavirus Pandemic (COVID-19) – the data](https://ourworldindata.org/coronavirus-data)